### PR TITLE
changed date/time fields in migrations to date/time from string.

### DIFF
--- a/database/migrations/20200421173510_create-tables.js
+++ b/database/migrations/20200421173510_create-tables.js
@@ -91,8 +91,8 @@ exports.up = function (knex) {
     })
     .createTable('diets', (tbl) => {
       tbl.increments();
-      tbl.string('meal_date').notNullable();
-      tbl.string('meal_time').notNullable();
+      tbl.date('meal_date').notNullable();
+      tbl.time('meal_time').notNullable();
       tbl.string('meal_category').notNullable();
       tbl.string('food_name').notNullable();
       tbl.decimal('food_quantity', null).notNullable();

--- a/validation/diet.js
+++ b/validation/diet.js
@@ -15,6 +15,7 @@ module.exports = function checkRegistrationFields(diet) {
     data.meal_category = ifEmpty(data.meal_category) ? data.meal_category : "";
     data.food_name = ifEmpty(data.food_name) ? data.food_name : "";
     data.meal_date = ifEmpty(data.meal_date) ? data.meal_date : "";
+    data.meal_time = ifEmpty(data.meal_time) ? data.meal_time : "";
     data.food_quantity = ifEmpty(data.food_quantity) ? data.food_quantity : "";
     data.food_calories = ifEmpty(data.food_calories) ? data.food_calories : "";
     data.food_fat = ifEmpty(data.food_fat) ? data.food_fat : "";
@@ -28,6 +29,8 @@ module.exports = function checkRegistrationFields(diet) {
         error.food_name = "A food name is required"
     if (!checkDate.test(data.meal_date))
         error.meal_date = "A valid date is required"
+    if (!checkValidTime.test(data.meal_time))
+        error.meal_time = "A valid time is required"
     if (data.food_quantity = "")
         error.food_quantity = "A valid quantity is required"
     if (data.food_calories = "")

--- a/validation/regex.js
+++ b/validation/regex.js
@@ -1,9 +1,11 @@
 const email = /^\S+@\S+\.\S+$/
 const checkDate = /^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$/
 const checkTime = /^(\d{1,2})?([MmHh])/
+const checkValidTime = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/
 
 module.exports = {
     email,
     checkDate,
-    checkTime
+    checkTime,
+    checkValidTime
 };


### PR DESCRIPTION
# Description
Changed string fields to date and time fields so food entries will show up on the calendar.

Fixes # (issue)
Times were not showing on the calendar

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] There are no merge conflicts
